### PR TITLE
Added scale filter

### DIFF
--- a/inkycal_xkcd.py
+++ b/inkycal_xkcd.py
@@ -33,9 +33,14 @@ class Xkcd(inkycal_module):
         "default": "latest"      
         },
     "alt": {
-        "label": "Would you like to add the alt text below the comic?",
+        "label": "Would you like to add the alt text below the comic? If XKCD is not the only module you are showing, I recommend setting this to 'no'",
         "options": ["yes", "no"],
-        "default": "yes"
+        "default": "no"
+        },
+    "filter": {
+        "label": "Would you like to add a scaling filter? If the is far too big to be shown in the space you've allotted for it, the module will try to find another image for you. This only applies in random mode. If XKCD is not the only module you are showing, I recommend setting this to 'no'.",
+        "options": ["yes", "no"],
+        "default": "no"
         }
     }
 
@@ -47,6 +52,7 @@ class Xkcd(inkycal_module):
    
     self.mode = config['mode']
     self.alt = config['alt']
+    self.scale_filter = config['filter']
 
     # give an OK message
     print(f'{filename} loaded')
@@ -97,13 +103,24 @@ class Xkcd(inkycal_module):
     logger.debug(f'line positions: {line_positions}')
       
     logger.info(f'getting xkcd comic...')
-            
+    
     if self.mode == 'random':
-        xkcdComic = xkcd.getRandomComic()
+        if self.scale_filter == 'no':
+            xkcdComic = xkcd.getRandomComic()
+        else:
+            perc = (2.1,0.4)
+            url = "test variable, not a real comic"
+            while max(perc) > 1.75:
+                print("looking for another comic, old comic was: ",perc, url)
+                xkcdComic = xkcd.getRandomComic()
+                xkcdComic.download(output=tmpPath, outputFile='xkcdComic.png')
+                actual_size = Image.open(tmpPath+'/xkcdComic.png').size
+                perc = (actual_size[0]/im_width,actual_size[1]/im_height)
+                url = xkcdComic.getImageLink()
+            print("found one! perc: ",perc, url)
     else:
         xkcdComic = xkcd.getLatestComic()
-    
-    xkcdComic.download(output=tmpPath, outputFile='xkcdComic.png')
+        xkcdComic.download(output=tmpPath, outputFile='xkcdComic.png')
 
     logger.info(f'got xkcd comic...')
     title_lines = []


### PR DESCRIPTION
This edit allows the module to check the size in pixels of the comic image and compares it to the size in pixels of the module. If either the x or the y of the comic is more than 1.75 times the size of the module, the code will try to randomly pull another comic until it finds one that is more suitable for the module size.

This filter will obviously cause issues if someone wants to put three modules onto a 7.5" screen; the smaller the module size is, the less comics will be available to them. To remedy this, the filter is an option, and in the label for the option I have recommended that it is only used if the xkcd module is the only module the user is displaying. I estimate that for a 100%-size xkcd module on a 7.5" inch screen, about 75% of xkcd comics will fit this criteria.

Also, the code will only apply this filter if the mode is set to "random". If the person wants the latest xkcd comic, they will get it, regardless of whether it's the proper size of their module. I've added this information in the label for the option.

Note: The 1.75 times the size metric is something that I anecdotally determined during testing. All the comics are unique and I obviously didn't look at all of them, but for a lot of the comics, 1.75 times the size is where the text starts to get difficult to read. If you don't mind squinting, you could increase this limit to 2 times the size, but I don't recommend it. This limit is set on line 113. I don't think we need to add another option for the user to be able to change this themselves.